### PR TITLE
Feature-gate debug prints in audio thread.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ stable_deref_trait = "1.0.0"
 
 [patch.crates-io]
 rocket = {git="https://github.com/SergioBenitez/Rocket", branch="master"}
+
+[features]
+debug_print_in_audio_thread = ["assert_no_alloc/warn_debug"]

--- a/src/engine/takes.rs
+++ b/src/engine/takes.rs
@@ -227,6 +227,7 @@ impl MidiTake {
 
 					if last_timestamp_before_loop < self.playback_position + range.len() as u32 {
 						// rewind only when the song actually passes the take length
+						#[cfg(feature = "debug_print_in_audio_thread")]
 						println!("MIDI REWIND");
 						self.events.rewind();
 
@@ -307,6 +308,7 @@ impl MidiTake {
 			if range.contains(&event.time()) {
 				if event.bytes().len() != 3 {
 					// FIXME
+					#[cfg(feature = "debug_print_in_audio_thread")]
 					println!("ignoring event with length != 3");
 				}
 				else {


### PR DESCRIPTION
When prints are enabled, then allocation checking is disabled
because println!() can allocate memory.